### PR TITLE
Update BaubleType.java to fix QualityToolsTransformer

### DIFF
--- a/src/main/java/baubles/api/BaubleType.java
+++ b/src/main/java/baubles/api/BaubleType.java
@@ -84,4 +84,8 @@ public enum BaubleType implements IBaubleType {
     public int[] getValidSlots() {
         return new int[] { -1, -1 };
     }
+
+    public static IBaubleType getType(String typeStr){
+        return BaubleType.valueOf(typeStr);
+    }
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/0081de0d-2dc8-4388-b4ff-28a9da3f0893)


BaubleType not have getType method